### PR TITLE
feat: :sparkles: añadi el border-top al footer

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -45,6 +45,7 @@ import { FooterItems } from './data.ts';
     position: relative;
     min-height: 277px;
     overflow: hidden;
+    border-top: 1px solid var(--text-color);
 
     &::before {
       content: '';


### PR DESCRIPTION
### Se añadió `boder-top` al componente footer

![image](https://github.com/user-attachments/assets/b6bc3550-e631-4790-927d-15ecfffbb723)
