### PR TITLE
fix: update links in navbar

### DIFF
--- a/src/components/Navbar/Navbar.astro
+++ b/src/components/Navbar/Navbar.astro
@@ -15,7 +15,7 @@ const items = [
 
 <header class="navbar-wrapper">
   <div class="container">
-    <a class="logo" href={import.meta.env.SITE} aria-label="UX Corp Rangel">
+    <a class="logo" href="/" aria-label="UX Corp Rangel">
       <Logo height={90} />
     </a>
 


### PR DESCRIPTION
# Actualizar enlaces del navbar

Se corrigen los enlaces del navbar al tener múltiples vistas. En el PR #23 se añade la vista de `/proyectos` pero el navbar deja de funcionar:

https://github.com/user-attachments/assets/8a5f2338-6f4e-469d-a69a-3d2e8b453f48

También se corrige el enlace del logo del navbar para que use una URL relativa en lugar de utilizar la constante `import.meta.env.SITE`:

https://github.com/user-attachments/assets/5eae3012-dced-47cc-a0a8-08915719e6b2
