### PR TITLE
fix: :bug: redirect to portfolios devs page

### DIFF
--- a/src/pages/portfolios-dev.astro
+++ b/src/pages/portfolios-dev.astro
@@ -41,7 +41,7 @@ import portfolios from '@data/portfolios';
 
 <style>
   main {
-    padding-block: 4rem;
+    padding-block: 4rem 18rem;
     width: 100%;
     max-width: 1280px;
     margin-inline: auto;

--- a/src/pages/proyectos.astro
+++ b/src/pages/proyectos.astro
@@ -81,12 +81,11 @@ import Layout from '@layouts/Layout.astro';
               photo="portfolio-dev.webp"
             >
               <LinkButton
-                label="Página"
-                link="https://unicorn-sparkle.web.app"
+                label="Portfolios"
+                link="/portfolios-dev"
                 icon="socials/website"
                 bgColor="var(--cinnabar-color)"
                 textColor="var(--text-color)"
-                external
               />
               <LinkButton label="GitHub" link="https://github.com/UXCorpRangel/portfolios-dev" icon="socials/github" external />
             </ProjectCard>
@@ -158,7 +157,7 @@ import Layout from '@layouts/Layout.astro';
               title="UX Corp Rangel"
               photo="uxCorp.webp"
             >
-              <LinkButton label="Página" link="/" icon="socials/website" bgColor="var(--cinnabar-color)" textColor="var(--text-color)" external />
+              <LinkButton label="Página" link="/" icon="socials/website" bgColor="var(--cinnabar-color)" textColor="var(--text-color)" />
               <LinkButton label="GitHub" link="/" icon="socials/github" external />
             </ProjectCard>
             {


### PR DESCRIPTION
se cambio en la página proyecto la dirección de los portfolios devs para ir a su página y ver todos los portfolios juntos, además se elimino el espacio sobrante debajo del footer
![image](https://github.com/user-attachments/assets/7d792a1b-dc89-4837-8845-b61af20f154b)

![image](https://github.com/user-attachments/assets/ace2396a-3045-44ce-af6d-1df9113a7424)
