### PR TITLE
fix: remove oneko in mobile devices

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,7 +59,11 @@ import Team from '@sections/Team.astro';
 </style>
 
 <script>
-  import HarleyOneko from '@scripts/harley-oneko';
+  const isHoverDevice = window.matchMedia('(any-hover: hover)').matches;
 
-  new HarleyOneko('/assets/images/harley-oneko.png');
+  if (isHoverDevice) {
+    import('@scripts/harley-oneko').then(HarleyOneko => {
+      new HarleyOneko.default('/assets/images/harley-oneko.png');
+    });
+  }
 </script>

--- a/src/scripts/harley-oneko.ts
+++ b/src/scripts/harley-oneko.ts
@@ -116,7 +116,7 @@ export default class HarleyOneko {
 
     document.body.appendChild(this.onekoEl);
 
-    document.addEventListener('mousemove', event => {
+    document.addEventListener('pointermove', (event: MouseEvent) => {
       this.mousePosX = event.clientX;
       this.mousePosY = event.clientY;
       this.onekoEl.style.zIndex = '2147483647';


### PR DESCRIPTION
Este PR soluciona #40.

Cambios realizados:
- Se reemplaza el uso del evento `mousemove` con `pointermove`, ya que este evento se ejecuta solamente en dispositivos con un puntero (mouse).
- Se convierte la instancia de la clase `HarleyOneko` a un import dinámico, para que se ejecute cuando se detecta que el dispositivo del usuario posee un puntero, en este caso se utilizó el método `window.matchMedia('(any-hover: hover)').matches` y evitar que la clase se ejecute en dispositivos táctiles como móviles para no crear innecesariamente el elemento HTML que contiene al oneko, aunque no se muestre debido al evento `pointermove`.

Antes:

https://github.com/user-attachments/assets/be9cd6d0-5f0c-4eef-a2d6-2fb0eeab0268

Después:

https://github.com/user-attachments/assets/8b5500c6-a5f3-46a8-aca2-6fd1307b9108
